### PR TITLE
Replace Avengers with rugby players

### DIFF
--- a/Avenger character animation/portfolio2023.michalzalobny.com/_next/static/chunks/pages/projects/motion-carousel-fd6275b92471bf97.js
+++ b/Avenger character animation/portfolio2023.michalzalobny.com/_next/static/chunks/pages/projects/motion-carousel-fd6275b92471bf97.js
@@ -23,61 +23,53 @@
                 app: null,
                 gui: null,
                 elementsArray: [{
-                    name: "Thor",
-                    description: "Asgardian god of thunder, whose enchanted hammer Mjolnir enables him to fly and manipulate weather, among his other superhuman attributes. A founding member of the superhero team the Avengers, Thor has a host of supporting characters and enemies",
+                    name: "Tendai Mtawarira",
+                    description: "Zimbabwe-born South African prop known as 'The Beast', celebrated for his power in the scrum.",
                     imgSrc: "/_next/static/media/3.c268897e.png",
                     imgBlurSrc: "/_next/static/media/3.85c9df8c.png",
                     order: 0,
                     assetSizeRatio: 1,
                     backgroundColor: [211.25, 50.67, 47.45]
                 }, {
-                    name: "Hulk",
-                    description: "Gigantic, green, irradiated, mutated humanoid monster with incredible strength and an inability to control his rage. The Hulk is sometimes characterized as hyper-aggressive and brutal, other times as cunning, brilliant, and scheming.",
+                    name: "Os du Randt",
+                    description: "Legendary Springbok loosehead prop who won Rugby World Cups in 1995 and 2007.",
                     imgSrc: "/_next/static/media/6.26bef12f.png",
                     imgBlurSrc: "/_next/static/media/6.aaa20048.png",
                     order: 1,
                     assetSizeRatio: 1,
                     backgroundColor: [72, 20.36, 39.96]
                 }, {
-                    name: "Iron Man",
-                    description: "Armored Avenger driven by a heart that is part machine, but all hero",
+                    name: "Gurthro Steenkamp",
+                    description: "Powerful prop who earned over 50 caps for South Africa and starred for Toulouse.",
                     imgSrc: "/_next/static/media/2.d201c21f.png",
                     imgBlurSrc: "/_next/static/media/2.c67bc47c.png",
                     order: 2,
                     assetSizeRatio: 1,
                     backgroundColor: [3, 42, 40.06]
                 }, {
-                    name: "Black Panther",
-                    description: "Member of the royal family of the fictional African country of Wakanda. After the death of his father, T'Challa claimed the throne and the role of Black Panther. He was exposed to a mystical herb that enhanced his strength and agility to near-superhuman levels",
+                    name: "Steven Kitshoff",
+                    description: "Dynamic loosehead prop for the Stormers and Springboks, admired for his work rate.",
                     imgSrc: "/_next/static/media/4.5f287e55.png",
                     imgBlurSrc: "/_next/static/media/4.a7ebfd51.png",
                     order: 3,
                     assetSizeRatio: 1,
                     backgroundColor: [240, 4, 13.43]
                 }, {
-                    name: "Ghost Rider",
-                    description: "Ghost Rider is a human who can transform into a skeletal superhuman wreathed in ethereal flame and given supernatural powers.",
+                    name: "Ox Nché",
+                    description: "Explosive young prop for the Sharks and South Africa, noted for his strength in contact.",
                     imgSrc: "/_next/static/media/5.438eeb32.png",
                     imgBlurSrc: "/_next/static/media/5.321f48d1.png",
                     order: 4,
                     assetSizeRatio: 1,
                     backgroundColor: [33.51, 52.83, 47.06]
                 }, {
-                    name: "Captain America",
-                    description: "Recipient of the Super Soldier serum, World War II hero Steve Rogers fights for American ideals as one of the world's mightiest heroes and the leader of the Avengers.",
+                    name: "Ollie le Roux",
+                    description: "Veteran prop with over 50 caps for the Springboks, respected for his scrummaging ability.",
                     imgSrc: "/_next/static/media/1.1122a8f6.png",
                     imgBlurSrc: "/_next/static/media/1.20293bda.png",
                     order: 5,
                     assetSizeRatio: 1,
                     backgroundColor: [221.54, 48.3, 41.96]
-                }, {
-                    name: "Spider Man",
-                    description: 'Superhuman strength, agility, endurance, ability to stick to and climb walls and other surfaces, uses self-designed web-shooters allowing him to fire and swing from sticky webs, special "Spider-Sense" warns of incoming danger, genius intellect specializing in chemistry and invention.',
-                    imgSrc: "/_next/static/media/7.e8fa660b.png",
-                    imgBlurSrc: "/_next/static/media/7.2cdb6f16.png",
-                    order: 6,
-                    assetSizeRatio: 1,
-                    backgroundColor: [350.2, 40.16, 47.84]
                 }],
                 planeGeometry: new n._12(1, 1, 1, 1),
                 scrollValuesGrid: {
@@ -1057,7 +1049,7 @@
                                 children: "Choose Character"
                             }), (0, r.jsx)("span", {}), (0, r.jsx)("p", {
                                 className: V().smallTitle,
-                                children: "Avengers"
+                                children: "Rugby Players"
                             })]
                         }), (0, r.jsxs)("div", {
                             className: V().contentWrapper,
@@ -1087,7 +1079,7 @@
                                         "data-motion-carousel": "heroTag",
                                         "data-animation": "paragraph",
                                         className: V().smallTitle,
-                                        children: "Avengers"
+                                        children: "Rugby Players"
                                     }), (0, r.jsx)("p", {
                                         className: V().heroTitle,
                                         "data-motion-carousel": "heroTitle",

--- a/Avenger character animation/portfolio2023.michalzalobny.com/projects/motion-carousel.html
+++ b/Avenger character animation/portfolio2023.michalzalobny.com/projects/motion-carousel.html
@@ -62,76 +62,64 @@
         <div class="Project_sharedVariables__nSTJG">
             <div data-motion-carousel="gridTitleWrapper" class="Project_titleWrapper__DDkOC">
                 <p class="Project_title__7ug2y">Choose Character</p><span></span>
-                <p class="Project_smallTitle__x7425">Avengers</p>
+                <p class="Project_smallTitle__x7425">Rugby Players</p>
             </div>
             <div class="Project_contentWrapper__1gY1w">
                 <div class="Project_focusedHolder__gpj_P" data-motion-carousel="focusedHolder"></div>
                 <div class="Project_infoHolder__VQxz8">
-                    <div data-heroname="Thor" data-motion-carousel="heroTextWrapper" class="Project_textWrapper__us5Ni">
+                    <div data-heroname="Tendai Mtawarira" data-motion-carousel="heroTextWrapper" class="Project_textWrapper__us5Ni">
                         <div style="width:100%;overflow:hidden;height:3px;margin-bottom:var(--margin-1)">
-                            <div data-heroname="Thor" data-motion-carousel="heroSeparator" class="Project_textSeparator__ifDR8"></div>
+                            <div data-heroname="Tendai Mtawarira" data-motion-carousel="heroSeparator" class="Project_textSeparator__ifDR8"></div>
                         </div>
-                        <p data-heroname="Thor" data-motion-carousel="heroTag" data-animation="paragraph" class="Project_smallTitle__x7425">Avengers</p>
-                        <p class="Project_heroTitle__Hfhqr" data-motion-carousel="heroTitle" data-animation="paragraph">Thor</p>
-                        <div data-heroname="Thor" data-motion-carousel="heroSeparatorBottom" class="Project_textSeparatorBottom__msMbI"></div>
-                        <p class="Project_heroDescription__y5i4U" data-motion-carousel="heroDescription" data-animation="paragraph">Asgardian god of thunder, whose enchanted hammer Mjolnir enables him to fly and manipulate weather, among his other superhuman attributes. A founding member of the superhero team the Avengers, Thor has a host of supporting characters
-                            and enemies</p>
+                        <p data-heroname="Tendai Mtawarira" data-motion-carousel="heroTag" data-animation="paragraph" class="Project_smallTitle__x7425">Rugby Players</p>
+                        <p class="Project_heroTitle__Hfhqr" data-motion-carousel="heroTitle" data-animation="paragraph">Tendai Mtawarira</p>
+                        <div data-heroname="Tendai Mtawarira" data-motion-carousel="heroSeparatorBottom" class="Project_textSeparatorBottom__msMbI"></div>
+                        <p class="Project_heroDescription__y5i4U" data-motion-carousel="heroDescription" data-animation="paragraph">Zimbabwe-born South African prop known as 'The Beast', celebrated for his power in the scrum.</p>
                     </div>
-                    <div data-heroname="Hulk" data-motion-carousel="heroTextWrapper" class="Project_textWrapper__us5Ni">
+                    <div data-heroname="Os du Randt" data-motion-carousel="heroTextWrapper" class="Project_textWrapper__us5Ni">
                         <div style="width:100%;overflow:hidden;height:3px;margin-bottom:var(--margin-1)">
-                            <div data-heroname="Hulk" data-motion-carousel="heroSeparator" class="Project_textSeparator__ifDR8"></div>
+                            <div data-heroname="Os du Randt" data-motion-carousel="heroSeparator" class="Project_textSeparator__ifDR8"></div>
                         </div>
-                        <p data-heroname="Hulk" data-motion-carousel="heroTag" data-animation="paragraph" class="Project_smallTitle__x7425">Avengers</p>
-                        <p class="Project_heroTitle__Hfhqr" data-motion-carousel="heroTitle" data-animation="paragraph">Hulk</p>
-                        <div data-heroname="Hulk" data-motion-carousel="heroSeparatorBottom" class="Project_textSeparatorBottom__msMbI"></div>
-                        <p class="Project_heroDescription__y5i4U" data-motion-carousel="heroDescription" data-animation="paragraph">Gigantic, green, irradiated, mutated humanoid monster with incredible strength and an inability to control his rage. The Hulk is sometimes characterized as hyper-aggressive and brutal, other times as cunning, brilliant, and scheming.</p>
+                        <p data-heroname="Os du Randt" data-motion-carousel="heroTag" data-animation="paragraph" class="Project_smallTitle__x7425">Rugby Players</p>
+                        <p class="Project_heroTitle__Hfhqr" data-motion-carousel="heroTitle" data-animation="paragraph">Os du Randt</p>
+                        <div data-heroname="Os du Randt" data-motion-carousel="heroSeparatorBottom" class="Project_textSeparatorBottom__msMbI"></div>
+                        <p class="Project_heroDescription__y5i4U" data-motion-carousel="heroDescription" data-animation="paragraph">Legendary Springbok loosehead prop who won Rugby World Cups in 1995 and 2007.</p>
                     </div>
-                    <div data-heroname="Iron Man" data-motion-carousel="heroTextWrapper" class="Project_textWrapper__us5Ni">
+                    <div data-heroname="Gurthro Steenkamp" data-motion-carousel="heroTextWrapper" class="Project_textWrapper__us5Ni">
                         <div style="width:100%;overflow:hidden;height:3px;margin-bottom:var(--margin-1)">
-                            <div data-heroname="Iron Man" data-motion-carousel="heroSeparator" class="Project_textSeparator__ifDR8"></div>
+                            <div data-heroname="Gurthro Steenkamp" data-motion-carousel="heroSeparator" class="Project_textSeparator__ifDR8"></div>
                         </div>
-                        <p data-heroname="Iron Man" data-motion-carousel="heroTag" data-animation="paragraph" class="Project_smallTitle__x7425">Avengers</p>
-                        <p class="Project_heroTitle__Hfhqr" data-motion-carousel="heroTitle" data-animation="paragraph">Iron Man</p>
-                        <div data-heroname="Iron Man" data-motion-carousel="heroSeparatorBottom" class="Project_textSeparatorBottom__msMbI"></div>
-                        <p class="Project_heroDescription__y5i4U" data-motion-carousel="heroDescription" data-animation="paragraph">Armored Avenger driven by a heart that is part machine, but all hero</p>
+                        <p data-heroname="Gurthro Steenkamp" data-motion-carousel="heroTag" data-animation="paragraph" class="Project_smallTitle__x7425">Rugby Players</p>
+                        <p class="Project_heroTitle__Hfhqr" data-motion-carousel="heroTitle" data-animation="paragraph">Gurthro Steenkamp</p>
+                        <div data-heroname="Gurthro Steenkamp" data-motion-carousel="heroSeparatorBottom" class="Project_textSeparatorBottom__msMbI"></div>
+                        <p class="Project_heroDescription__y5i4U" data-motion-carousel="heroDescription" data-animation="paragraph">Powerful prop who earned over 50 caps for South Africa and starred for Toulouse.</p>
                     </div>
-                    <div data-heroname="Black Panther" data-motion-carousel="heroTextWrapper" class="Project_textWrapper__us5Ni">
+                    <div data-heroname="Steven Kitshoff" data-motion-carousel="heroTextWrapper" class="Project_textWrapper__us5Ni">
                         <div style="width:100%;overflow:hidden;height:3px;margin-bottom:var(--margin-1)">
-                            <div data-heroname="Black Panther" data-motion-carousel="heroSeparator" class="Project_textSeparator__ifDR8"></div>
+                            <div data-heroname="Steven Kitshoff" data-motion-carousel="heroSeparator" class="Project_textSeparator__ifDR8"></div>
                         </div>
-                        <p data-heroname="Black Panther" data-motion-carousel="heroTag" data-animation="paragraph" class="Project_smallTitle__x7425">Avengers</p>
-                        <p class="Project_heroTitle__Hfhqr" data-motion-carousel="heroTitle" data-animation="paragraph">Black Panther</p>
-                        <div data-heroname="Black Panther" data-motion-carousel="heroSeparatorBottom" class="Project_textSeparatorBottom__msMbI"></div>
-                        <p class="Project_heroDescription__y5i4U" data-motion-carousel="heroDescription" data-animation="paragraph">Member of the royal family of the fictional African country of Wakanda. After the death of his father, T&#x27;Challa claimed the throne and the role of Black Panther. He was exposed to a mystical herb that enhanced his strength
-                            and agility to near-superhuman levels</p>
+                        <p data-heroname="Steven Kitshoff" data-motion-carousel="heroTag" data-animation="paragraph" class="Project_smallTitle__x7425">Rugby Players</p>
+                        <p class="Project_heroTitle__Hfhqr" data-motion-carousel="heroTitle" data-animation="paragraph">Steven Kitshoff</p>
+                        <div data-heroname="Steven Kitshoff" data-motion-carousel="heroSeparatorBottom" class="Project_textSeparatorBottom__msMbI"></div>
+                        <p class="Project_heroDescription__y5i4U" data-motion-carousel="heroDescription" data-animation="paragraph">Dynamic loosehead prop for the Stormers and Springboks, admired for his work rate.</p>
                     </div>
-                    <div data-heroname="Ghost Rider" data-motion-carousel="heroTextWrapper" class="Project_textWrapper__us5Ni">
+                    <div data-heroname="Ox Nché" data-motion-carousel="heroTextWrapper" class="Project_textWrapper__us5Ni">
                         <div style="width:100%;overflow:hidden;height:3px;margin-bottom:var(--margin-1)">
-                            <div data-heroname="Ghost Rider" data-motion-carousel="heroSeparator" class="Project_textSeparator__ifDR8"></div>
+                            <div data-heroname="Ox Nché" data-motion-carousel="heroSeparator" class="Project_textSeparator__ifDR8"></div>
                         </div>
-                        <p data-heroname="Ghost Rider" data-motion-carousel="heroTag" data-animation="paragraph" class="Project_smallTitle__x7425">Avengers</p>
-                        <p class="Project_heroTitle__Hfhqr" data-motion-carousel="heroTitle" data-animation="paragraph">Ghost Rider</p>
-                        <div data-heroname="Ghost Rider" data-motion-carousel="heroSeparatorBottom" class="Project_textSeparatorBottom__msMbI"></div>
-                        <p class="Project_heroDescription__y5i4U" data-motion-carousel="heroDescription" data-animation="paragraph">Ghost Rider is a human who can transform into a skeletal superhuman wreathed in ethereal flame and given supernatural powers.</p>
+                        <p data-heroname="Ox Nché" data-motion-carousel="heroTag" data-animation="paragraph" class="Project_smallTitle__x7425">Rugby Players</p>
+                        <p class="Project_heroTitle__Hfhqr" data-motion-carousel="heroTitle" data-animation="paragraph">Ox Nché</p>
+                        <div data-heroname="Ox Nché" data-motion-carousel="heroSeparatorBottom" class="Project_textSeparatorBottom__msMbI"></div>
+                        <p class="Project_heroDescription__y5i4U" data-motion-carousel="heroDescription" data-animation="paragraph">Explosive young prop for the Sharks and South Africa, noted for his strength in contact.</p>
                     </div>
-                    <div data-heroname="Captain America" data-motion-carousel="heroTextWrapper" class="Project_textWrapper__us5Ni">
+                    <div data-heroname="Ollie le Roux" data-motion-carousel="heroTextWrapper" class="Project_textWrapper__us5Ni">
                         <div style="width:100%;overflow:hidden;height:3px;margin-bottom:var(--margin-1)">
-                            <div data-heroname="Captain America" data-motion-carousel="heroSeparator" class="Project_textSeparator__ifDR8"></div>
+                            <div data-heroname="Ollie le Roux" data-motion-carousel="heroSeparator" class="Project_textSeparator__ifDR8"></div>
                         </div>
-                        <p data-heroname="Captain America" data-motion-carousel="heroTag" data-animation="paragraph" class="Project_smallTitle__x7425">Avengers</p>
-                        <p class="Project_heroTitle__Hfhqr" data-motion-carousel="heroTitle" data-animation="paragraph">Captain America</p>
-                        <div data-heroname="Captain America" data-motion-carousel="heroSeparatorBottom" class="Project_textSeparatorBottom__msMbI"></div>
-                        <p class="Project_heroDescription__y5i4U" data-motion-carousel="heroDescription" data-animation="paragraph">Recipient of the Super Soldier serum, World War II hero Steve Rogers fights for American ideals as one of the world&#x27;s mightiest heroes and the leader of the Avengers.</p>
-                    </div>
-                    <div data-heroname="Spider Man" data-motion-carousel="heroTextWrapper" class="Project_textWrapper__us5Ni">
-                        <div style="width:100%;overflow:hidden;height:3px;margin-bottom:var(--margin-1)">
-                            <div data-heroname="Spider Man" data-motion-carousel="heroSeparator" class="Project_textSeparator__ifDR8"></div>
-                        </div>
-                        <p data-heroname="Spider Man" data-motion-carousel="heroTag" data-animation="paragraph" class="Project_smallTitle__x7425">Avengers</p>
-                        <p class="Project_heroTitle__Hfhqr" data-motion-carousel="heroTitle" data-animation="paragraph">Spider Man</p>
-                        <div data-heroname="Spider Man" data-motion-carousel="heroSeparatorBottom" class="Project_textSeparatorBottom__msMbI"></div>
-                        <p class="Project_heroDescription__y5i4U" data-motion-carousel="heroDescription" data-animation="paragraph">Superhuman strength, agility, endurance, ability to stick to and climb walls and other surfaces, uses self-designed web-shooters allowing him to fire and swing from sticky webs, special &quot;Spider-Sense&quot; warns of incoming
-                            danger, genius intellect specializing in chemistry and invention.</p>
+                        <p data-heroname="Ollie le Roux" data-motion-carousel="heroTag" data-animation="paragraph" class="Project_smallTitle__x7425">Rugby Players</p>
+                        <p class="Project_heroTitle__Hfhqr" data-motion-carousel="heroTitle" data-animation="paragraph">Ollie le Roux</p>
+                        <div data-heroname="Ollie le Roux" data-motion-carousel="heroSeparatorBottom" class="Project_textSeparatorBottom__msMbI"></div>
+                        <p class="Project_heroDescription__y5i4U" data-motion-carousel="heroDescription" data-animation="paragraph">Veteran prop with over 50 caps for the Springboks, respected for his scrummaging ability.</p>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- update the carousel markup to list rugby players instead of Avengers
- update the JavaScript bundle with rugby player data

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6848a3614a50832a8f7ded4def1fc9bf